### PR TITLE
google-auth 2.6.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,6 +41,8 @@ test:
     - google.auth
   commands:
     - python -m pip check
+  downstreams:
+    - google-cloud-storage
 
 about:
   home: https://github.com/googleapis/google-auth-library-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,13 +18,13 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
     - pip
     - wheel
   run:
     - python >=3.6
-    - cachetools >=2.0.0,<5.0
+    - cachetools >=2.0.0,<6.0
     - pyasn1-modules >=0.2.1
     - rsa >=3.1.4,<5
     - setuptools >=40.3.0
@@ -36,7 +36,6 @@ requirements:
 
 test:
   requires:
-    - python
     - pip
   imports:
     - google.auth

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "google-auth" %}
-{% set version = "1.33.0" %}
-{% set sha256 = "9bd25d835c01ca3dd9045ea0b50f036e3fe3868ee2c5a9773a661925bbdf46ca" %}
+{% set version = "2.6.0" %}
+{% set sha256 = "ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Update google-auth to 2.6.0 for google-cloud-core -> gensim 4.1.2

Changelog: https://github.com/googleapis/google-auth-library-python/blob/main/CHANGELOG.md
License: https://github.com/googleapis/google-auth-library-python/blob/v2.6.0/LICENSE
Upstream setup.py: https://github.com/googleapis/google-auth-library-python/blob/v2.6.0/setup.py

The package google-auth is mentioned inside the packages:
airflow | google-api-core | google-auth-oauthlib | google-cloud-storage | pydata-google-auth | python-kubernetes | ray-packages |

Actions:
1. Fix python in host
2. Update run: `cachetools >=2.0.0,<6.0`
3. Remove python from test/requires
4. Add `downstreams`: google-cloud-storage