### PR TITLE
[PKG-2768] google-auth 2.22.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,20 +1,18 @@
 {% set name = "google-auth" %}
-{% set version = "2.6.0" %}
-{% set sha256 = "ad160fc1ea8f19e331a16a14a79f3d643d813a69534ba9611d2c80dc10439dad" %}
+{% set version = "2.22.0" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: 164cba9af4e6e4e40c3a4f90a1a6c12ee56f14c0b4868d1ca91b32826ab334ce
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
@@ -23,16 +21,19 @@ requirements:
     - pip
     - wheel
   run:
-    - python >=3.6
+    - python
     - cachetools >=2.0.0,<6.0
     - pyasn1-modules >=0.2.1
     - rsa >=3.1.4,<5
-    - setuptools >=40.3.0
     - six >=1.9.0
-    # extras
+    - urllib3 <2.0
+  run_constrained:
     - aiohttp >=3.6.2,<4.0.0dev
     - requests >=2.20.0,<3.0.0dev
     - pyopenssl >=20.0.0
+    - cryptography >=38.0.3
+    # 2023/9/7: pyu2f isn't available on defaults yet
+    - pyu2f >=0.1.5
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,11 @@ requirements:
     - rsa >=3.1.4,<5
     - six >=1.9.0
     - urllib3 <2.0
-  run_constrained:
+    # extras: keep them in run to avoid breaking environments
     - aiohttp >=3.6.2,<4.0.0dev
     - requests >=2.20.0,<3.0.0dev
     - pyopenssl >=20.0.0
+    run_constrained:
     - cryptography >=38.0.3
     # 2023/9/7: pyu2f isn't available on defaults yet
     - pyu2f >=0.1.5
@@ -51,7 +52,9 @@ about:
   license_family: Apache
   license_file: LICENSE
   summary: Google authentication library for Python
-  description: This library provides the ability to authenticate to Google APIs using various methods. It also provides integration with several HTTP libraries.
+  description: |
+    This library provides the ability to authenticate to Google APIs using various methods. 
+    It also provides integration with several HTTP libraries.
   doc_url: https://google-auth.readthedocs.io/en/latest/
   dev_url: https://github.com/googleapis/google-auth-library-python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - aiohttp >=3.6.2,<4.0.0dev
     - requests >=2.20.0,<3.0.0dev
     - pyopenssl >=20.0.0
-    run_constrained:
+  run_constrained:
     - cryptography >=38.0.3
     # 2023/9/7: pyu2f isn't available on defaults yet
     - pyu2f >=0.1.5


### PR DESCRIPTION
 Changelog: https://github.com/googleapis/google-auth-library-python/blob/v2.22.0/CHANGELOG.md
 License: https://github.com/googleapis/google-auth-library-python/blob/v2.22.0/LICENSE
 Requirements: https://github.com/googleapis/google-auth-library-python/blob/v2.22.0/setup.py

 Actions:
 1. Skip py<36 and remove noarch python
 2. Add --no-build-isolation to script
 3. Fix python pinning in run
 4. Update run dependencies. Note: do not remove extras as they can break the user environments and we try to provide the same functionality
 5. Add run_constrainted for new extras
    